### PR TITLE
Changed: SMTPClient class ...

### DIFF
--- a/smtp2go/core.py
+++ b/smtp2go/core.py
@@ -44,13 +44,12 @@ class Smtp2goClient:
     Smtp2goResponse instance
     """
 
-    def __init__(self, api_key=None): 
+    def __init__(self, api_key=None):
 	self.api_key = api_key or os.getenv('SMTP2GO_API_KEY', None)
         if not self.api_key:
             raise Smtp2goAPIKeyException(
-                'Smtp2goClient requires the api_key to be set.'
-		'Either set via environment variable \'SMTP2GO_API_KEY\''
-                'or define Smtp2goClient(api_key)')
+                'Smtp2goClient requires api_key as SMTP2GO_API_KEY Environment Variable to be set'
+                )
 
     def send(self, sender, recipients, subject, text=None,
              html=None, custom_headers=None, **kwargs):

--- a/smtp2go/core.py
+++ b/smtp2go/core.py
@@ -44,12 +44,13 @@ class Smtp2goClient:
     Smtp2goResponse instance
     """
 
-    def __init__(self):
-        self.api_key = os.getenv('SMTP2GO_API_KEY', None)
+    def __init__(self, api_key=None): 
+	self.api_key = api_key or os.getenv('SMTP2GO_API_KEY', None)
         if not self.api_key:
             raise Smtp2goAPIKeyException(
-                'Smtp2goClient requires SMTP2GO_API_KEY Environment Variable '
-                'to be set')
+                'Smtp2goClient requires the api_key to be set.'
+		'Either set via environment variable \'SMTP2GO_API_KEY\''
+                'or define Smtp2goClient(api_key)')
 
     def send(self, sender, recipients, subject, text=None,
              html=None, custom_headers=None, **kwargs):

--- a/smtp2go/core.py
+++ b/smtp2go/core.py
@@ -45,14 +45,14 @@ class Smtp2goClient:
     """
 
     def __init__(self, api_key=None):
-	self.api_key = api_key or os.getenv('SMTP2GO_API_KEY', None)
+        self.api_key = api_key or os.getenv('SMTP2GO_API_KEY', None)
         if not self.api_key:
             raise Smtp2goAPIKeyException(
                 'Smtp2goClient requires api_key as SMTP2GO_API_KEY Environment Variable to be set'
                 )
 
     def send(self, sender, recipients, subject, text=None,
-             html=None, custom_headers=None, **kwargs):
+            html=None, custom_headers=None, **kwargs):
 
         # Ensure that either html or text was passed:
         if not any([text, html]):


### PR DESCRIPTION
... to allow api_key declaration without relying on environment variables

I am coding a plugin for another program which will utilize smtp2go as a dependency, and being able to set the api_key within a configuration file was preferable to declaring an environment variable because all users require access to it, but neither does the program run as root, which is not ideal.

In general, forcing the user to set environment variables is not friendly to developers, hence the change. The changes are made such that the user can declare the api_key when the class is instantiated without requiring the environment variable, but still performs a check for the presence of the environment variable if api_key is unset at the time of instantiation. This is to avoid breaking compatibility or existing installations.